### PR TITLE
Adds missing period type from pprof

### DIFF
--- a/lib/src/main/java/jpprof/jfr2pprof.java
+++ b/lib/src/main/java/jpprof/jfr2pprof.java
@@ -67,6 +67,7 @@ public class jfr2pprof {
     public static final int PROFILE_STRING_TABLE = 6;
     public static final int PROFILE_TIME_NANOS = 9;
     public static final int PROFILE_DURATION_NANOS = 10;
+    public static final int PROFILE_PERIOD_TYPE = 11;
     public static final int PROFILE_COMMENT = 13;
     public static final int PROFILE_DEFAULT_SAMPLE_TYPE = 14;
 
@@ -116,7 +117,6 @@ public class jfr2pprof {
                 .field(PROFILE_COMMENT, stringId++);
 
         final Proto sampleType = new Proto(100);
-
         profile.field(PROFILE_STRING_TABLE, "cpu".getBytes(StandardCharsets.UTF_8));
         sampleType.field(VALUETYPE_TYPE, stringId++);
 
@@ -124,6 +124,7 @@ public class jfr2pprof {
         sampleType.field(VALUETYPE_UNIT, stringId++);
 
         profile.field(PROFILE_SAMPLE_TYPE, sampleType);
+        profile.field(PROFILE_PERIOD_TYPE, sampleType);
 
         final List<ExecutionSample> jfrSamples = reader.readAllEvents(ExecutionSample.class);
         final Dictionary<StackTrace> stackTraces = reader.stackTraces;

--- a/lib/src/test/java/jpprof/LibraryTest.java
+++ b/lib/src/test/java/jpprof/LibraryTest.java
@@ -6,16 +6,15 @@ package jpprof;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.util.zip.GZIPOutputStream;
-
-import one.jfr.JfrReader;
-import one.profiler.*;
+import java.io.*;
+import java.time.Duration;
 
 public class LibraryTest {
     @Test
-    public void TestJFR() {
-
+    public void TestPProf() throws Exception {
+        File file = File.createTempFile("abc", ".tmp");
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            CPUProfiler.start(Duration.ofSeconds(5), fos);
+        }
     }
 }


### PR DESCRIPTION
The period type was missing causing the profile type name to be a bit different for java.

This also default to local library if not found in resource.