### PR TITLE
Update build.gradle

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:31.0.1-jre'
-    implementation('me.bechberger:ap-loader:2.8.3-all-SNAPSHOT') {
+    implementation('me.bechberger:ap-loader:2.9-2-all') {
         changing = true
     }
 }


### PR DESCRIPTION
I understand this project was a proof of concept and is not designed to be future-proof. Because everything should be replaced by pyroscope agent.
So if you wish to close this PR I would totally get it.

Pushing a new version of ap-loader, because there is a bugfix upstream https://github.com/jvm-profiling-tools/ap-loader/pull/12 to use the right version for ARM (hence graviton) instances.
Would it be possible to push a new version `0.1.7`?

We can push it on our nexus, but I feel it could help others while they/we are migrating to pyroscope.
So if that doesn't take much of your time for a dead project, I would be glad!

Thanks @cyriltovena !